### PR TITLE
Add append event support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-eventstore",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Eventlog for orbit-db",
   "main": "src/EventStore.js",
   "homepage": "https://github.com/orbitdb/orbit-db-eventstore",
@@ -21,7 +21,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-    "orbit-db-store": "~3.1.0"
+    "orbit-db-store": "~3.3.0"
   },
   "devDependencies": {
     "standard": "^12.0.1"

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -10,12 +10,9 @@ class EventStore extends Store {
     if (options.Index === undefined) Object.assign(options, { Index: EventIndex })
     super(ipfs, id, dbname, options)
     this._type = 'eventlog';
-    this.events.on("replicated.progress", (address, hash, entry, progress, have) => {
-      this._procEntry(entry);
-    });
-    this.events.on("write", (address, entry, heads) => {
-      this._procEntry(entry);
-    });
+    this.events.on("log.op.ADD", (address, hash, payload) => {
+      this.events.emit("db.append", payload.value)
+    })
   }
 
   add (data, options = {}) {
@@ -81,14 +78,6 @@ class EventStore extends Store {
     // Slice the array to its requested size
     const res = ops.slice(startIndex).slice(0, amount)
     return res
-  }
-  _procEntry(entry) {
-    var {op, value} = entry.payload;
-    switch(op) {
-      case "ADD": {
-        this.events.emit("db.append", value)
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Adds support for append event. Append event is triggered when a entry is written locally, or replicated from other peers. Is not emitted when DB is loading. The output is the entry that is added to the eventstore.